### PR TITLE
Fixing syslog and elastic search log forwarding

### DIFF
--- a/playbooks/roles/ocp-cluster-logging/templates/clf-instance.yml.j2
+++ b/playbooks/roles/ocp-cluster-logging/templates/clf-instance.yml.j2
@@ -8,6 +8,9 @@
         name: instance 
         namespace: openshift-logging 
       spec:
+        outputDefaults:
+          elasticsearch:
+            structuredTypeKey: openshift.labels.logs
         outputs:
 {% if elasticsearch_server_url is defined %}
         - name: elasticsearch-insecure
@@ -28,9 +31,11 @@
             msgID: mymsg
             procID: myproc
             severity: informational
-          url: "{{ syslog_server_url }}" 
+          url: "{{ syslog_server_url }}"
+{% if 'tls' in syslog_server_url %}
           secret: 
               name: syslog-secret
+{% endif %}
         - name: rsyslog-infra
           type: syslog 
           syslog: 
@@ -40,9 +45,11 @@
             msgID: mymsg
             procID: myproc
             severity: informational
-          url: "{{ syslog_server_url }}" 
+          url: "{{ syslog_server_url }}"
+{% if 'tls' in syslog_server_url %}
           secret: 
               name: syslog-secret
+{% endif %}
         - name: rsyslog-audit
           type: syslog 
           syslog: 
@@ -52,9 +59,11 @@
             msgID: mymsg
             procID: myproc
             severity: informational
-          url: "{{ syslog_server_url }}" 
+          url: "{{ syslog_server_url }}"
+{% if 'tls' in syslog_server_url %}
           secret: 
               name: syslog-secret
+{% endif %}
 {% endif %}
 {% if kafka_server_url is defined %}
         - name: kafka-app-logs


### PR DESCRIPTION
Issue: For cluster logging operator version 5.5.x, cluster log forwarder unable to send logs to the external syslog and elastic-search.


Signed-off-by: Varad Ahirwadkar <varad.ahirwadkar@ibm.com>