### PR TITLE
Removing Go lang installation variables from VPA role

### DIFF
--- a/playbooks/roles/ocp-vpa-operator/README.md
+++ b/playbooks/roles/ocp-vpa-operator/README.md
@@ -61,6 +61,8 @@ Role Variables
 | vpa_e2e | no | false | It executes the VPA e2e |
 | vpa_cleanup | no | false | It is used to clean the VPA resources only |
 
+Note: To set the go lang version and path please use the variables from the `golang-installation` role. Please make sure, value for `golang_installation_path` is `/usr/local/`.
+
 Dependencies
 ------------
 

--- a/playbooks/roles/ocp-vpa-operator/tasks/vpa-e2e.yml
+++ b/playbooks/roles/ocp-vpa-operator/tasks/vpa-e2e.yml
@@ -8,9 +8,6 @@
 - name: Include role for installation of Go lang
   include_role:
     name: golang-installation
-  vars:
-    go_tarball: "{{ golang_tarball_sbo | default('https://dl.google.com/go/go1.17.6.linux-ppc64le.tar.gz', true) }}" 
-    golang_path: "/usr/local/"
 
 - name: Run VPA e2e tests
   shell: |


### PR DESCRIPTION
Updating this role because Go lang version `go1.17.6` is not working for VPA e2e tests

Signed-off-by: Varad Ahirwadkar <varad.ahirwadkar@ibm.com>