### PR TITLE
Updating Ruby module for verification tests

### DIFF
--- a/playbooks/roles/ocp-verification-tests/tasks/main.yml
+++ b/playbooks/roles/ocp-verification-tests/tasks/main.yml
@@ -5,10 +5,22 @@
       - git
     state: latest
 
-- name: Install Ruby-3 package
-  shell: |
-    sudo dnf module reset ruby -y
-    sudo dnf install -y @ruby:3.0
+- name: Uninstall Ruby
+  ansible.builtin.dnf:
+    name: ruby
+    state: absent
+
+- name: Reset the Ruby module
+  shell: sudo dnf module reset ruby -y
+
+- name: Get latest stream for Ruby
+  shell: dnf module list ruby | grep ruby | awk 'END {print $2}'
+  register: latest_stream
+
+- name: Install latest Ruby module
+  ansible.builtin.dnf:
+    name: '@ruby:{{ latest_stream.stdout }}'
+    state: present
 
 - name: Create user with username testuser
   include_role:


### PR DESCRIPTION
Ruby installation fails due to Ruby module stream 3.0 is unavailable on RHEL 9

```
# dnf module list ruby
Failed to set locale, defaulting to C.UTF-8
Updating Subscription Management repositories.
Last metadata expiration check: 2:13:48 ago on Tue Feb  7 21:28:49 2023.
Red Hat Enterprise Linux 9 for Power, little endian - AppStream (RPMs)
Name       Stream        Profiles            Summary
ruby       3.1 [e]       common [d] [i]      An interpreter of object-oriented scripting language

Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled
```

Signed-off-by: Varad Ahirwadkar <varad.ahirwadkar@ibm.com>