### PR TITLE
Add fix to work for EC and RC builds

### DIFF
--- a/playbooks/roles/ocp-verification-tests/tasks/main.yml
+++ b/playbooks/roles/ocp-verification-tests/tasks/main.yml
@@ -67,7 +67,7 @@
   register: server_url
 
 - name: Get the OCP version
-  shell: oc version -o json | jq '.openshiftVersion'
+  shell: oc version -o json | jq '.openshiftVersion' | sed 's/-.*//' |  sed 's/"//'
   register: ocp_cluster_version
 
 - name: Creates directory


### PR DESCRIPTION
The environment variable for the OCP version expected by the verification tests is not of the type EC or RC builds.

	Example:
	The tests fail for "4.13.0-ec.3" and tests pass for "4.13.0".
