### PR TITLE
Fix issues metallb-BGP and openshift e2e summary count

### DIFF
--- a/playbooks/roles/ocp-e2e/tasks/main.yml
+++ b/playbooks/roles/ocp-e2e/tasks/main.yml
@@ -147,7 +147,7 @@
 - name: Prepare test suites and run e2e tests
   shell: |
     openshift-tests run openshift/conformance/parallel --dry-run | ./invert_excluded.py excluded_tests > test-suite.txt
-    openshift-tests run -f ./test-suite.txt {{ repository_command }} -o {{ results_dir }}/conformance-parallel-out-0.txt --junit-dir {{ results_dir }}/conformance-parallel &> {{ results_dir }}/openshift-cmd-out-log-0.txt
+    openshift-tests run -f ./test-suite.txt {{ repository_command }} -o {{ results_dir }}/conformance-parallel-out-0.txt --junit-dir {{ results_dir }}/conformance-parallel > {{ results_dir }}/openshift-cmd-out-log-0.txt 2>&1
     sed -e 's/\"/\\"/g;s/.*/\"&\"/'  {{ results_dir }}/conformance-parallel-out-0.txt   | awk '/Failing tests:/,EOF' | tail -n +3 | head -n -4 > {{ results_dir }}/failed-e2e-results.txt
   args:
     chdir: "{{ test_dir }}/origin"
@@ -159,7 +159,7 @@
 - name: Re run e2e failed tests
   shell: |
     cnt=0
-    IFS=' ' read -ra ADDR1 <<< $(cat {{ results_dir }}/openshift-cmd-out-log-0.txt | tail -1 | grep -o "error: [0-9]* fail, [0-9]* pass, [0-9]* skip (\([0-9]*h[0-9]*m[0-9]*s\|[0-9]*m[0-9]*s\))")
+    IFS=' ' read -ra ADDR1 <<< $(cat {{ results_dir }}/openshift-cmd-out-log-0.txt | tail -1 | grep -o "error: [0-9]* fail, [0-9]* pass, [0-9]* skip (\([0-9]*h[0-9]*m[0-9]*s\|[0-9]*m[0-9]*s\|[0-9.]*s\))")
     if  [ "0" -ne "$(wc -l < "{{ results_dir }}/failed-e2e-results.txt")" ]
     then
       # Storing start time
@@ -176,7 +176,7 @@
         sed -e 's/\"/\\"/g;s/.*/\"&\"/' "{{ results_dir }}/conformance-parallel-out-${cnt}.txt" | awk '/Failing tests:/,EOF' | tail -n +3 | head -n -4 > {{ results_dir }}/failed-e2e-results.txt
         awk -i inplace '/\S/' "{{ results_dir }}/failed-e2e-results.txt"
 
-        IFS=' ' read -ra ADDR2 <<< $(cat {{ results_dir }}/openshift-cmd-out-log-${cnt}.txt | tail -1 | grep -o "error: [0-9]* fail, [0-9]* pass, [0-9]* skip (\([0-9]*h[0-9]*m[0-9]*s\|[0-9]*m[0-9]*s\))")
+        IFS=' ' read -ra ADDR2 <<< $(cat {{ results_dir }}/openshift-cmd-out-log-${cnt}.txt | tail -1 | grep -o "error: [0-9]* fail, [0-9]* pass, [0-9]* skip (\([0-9]*h[0-9]*m[0-9]*s\|[0-9]*m[0-9]*s\|[0-9.]*s\))")
         # Calculating the passed and skipped test cases
         if [ ${{ "{" }}{{ "#" }}ADDR2[@]} -eq "5" ]
         then
@@ -207,7 +207,7 @@
       echo " ${ADDR2[1]} fail, ${ADDR1[3]} pass, ${ADDR1[5]} skip $e2e_time" >  {{ results_dir }}/summary.txt
     else
        mv {{ results_dir }}/conformance-parallel-out-0.txt {{ results_dir }}/conformance-parallel-out.txt
-       summary=$(cat {{ results_dir }}/openshift-cmd-out-log-0.txt | tail -1 | grep -o "error: [0-9]* fail, [0-9]* pass, [0-9]* skip (\([0-9]*h[0-9]*m[0-9]*s\|[0-9]*m[0-9]*s\))")
+       summary=$(cat {{ results_dir }}/openshift-cmd-out-log-0.txt | tail -1 | grep -o "error: [0-9]* fail, [0-9]* pass, [0-9]* skip (\([0-9]*h[0-9]*m[0-9]*s\|[0-9]*m[0-9]*s\|[0-9.]*s\))")
        sed -e 's/\"/\\"/g;s/.*/\"&\"/'  {{ results_dir }}/conformance-parallel-out.txt   | awk '/Failing tests:/,EOF' | tail -n +3 | head -n -4 > {{ results_dir }}/failed-e2e-results.txt
        echo $summary |sed 's/error://' >> {{ results_dir }}/summary.txt
     fi

--- a/playbooks/roles/ocp-metallb-operator/tasks/e2e.yml
+++ b/playbooks/roles/ocp-metallb-operator/tasks/e2e.yml
@@ -1327,7 +1327,7 @@
     kubernetes.core.k8s:
       state: present
       definition:
-        apiVersion: metallb.io/v1beta1
+        apiVersion: metallb.io/v1beta2
         kind: BGPPeer
         metadata:
           name: peer-no-bfd


### PR DESCRIPTION
- Added regular expression to grep sec if re-running test case takes less then a minute
- Updated the metallb operator e2e BGPPeer apiVersion for fixing bgp error in 4.14 latest builds