### PR TITLE
fix e2e summary issue: Adding workaround for e2e summary issue.

### DIFF
--- a/playbooks/roles/ocp-e2e/tasks/main.yml
+++ b/playbooks/roles/ocp-e2e/tasks/main.yml
@@ -148,7 +148,7 @@
     oc get secret/pull-secret -n openshift-config -o json | jq -r '.data.".dockerconfigjson"' | base64 -d > authfile
     mkdir -p /run/user/0/containers/
     cp authfile /run/user/0/containers/auth.json
-  when: e2e_tests_git_branch == 'release-4.15'  
+  when: e2e_tests_git_branch == 'release-4.16'  
 
 # Running E2E
 - name: Prepare test suites and run e2e tests
@@ -166,7 +166,8 @@
 - name: Re run e2e failed tests
   shell: |
     cnt=0
-    IFS=' ' read -ra ADDR1 <<< $(cat {{ results_dir }}/openshift-cmd-out-log-0.txt | tail -1 | grep -o "error: [0-9]* fail, [0-9]* pass, [0-9]* skip (\([0-9]*h[0-9]*m[0-9]*s\|[0-9]*m[0-9]*s\|[0-9.]*s\))")
+    pattern="(error: [0-9]* fail, [0-9]* pass, [0-9]* skip|[0-9]* pass, [0-9]* skip) \(([0-9]*h[0-9]*m[0-9]*s|[0-9]*m[0-9]*s|[0-9.]*s)\)"
+    IFS=' ' read -ra ADDR1 <<< $(cat {{ results_dir }}/openshift-cmd-out-log-0.txt | tail -5 | grep -oE "${pattern}" | head -1)
     if  [ "0" -ne "$(wc -l < "{{ results_dir }}/failed-e2e-results.txt")" ]
     then
       # Storing start time
@@ -183,16 +184,22 @@
         sed -e 's/\"/\\"/g;s/.*/\"&\"/' "{{ results_dir }}/conformance-parallel-out-${cnt}.txt" | awk '/Failing tests:/,EOF' | tail -n +3 | head -n -4 > {{ results_dir }}/failed-e2e-results.txt
         awk -i inplace '/\S/' "{{ results_dir }}/failed-e2e-results.txt"
 
-        IFS=' ' read -ra ADDR2 <<< $(cat {{ results_dir }}/openshift-cmd-out-log-${cnt}.txt | tail -1 | grep -o "error: [0-9]* fail, [0-9]* pass, [0-9]* skip (\([0-9]*h[0-9]*m[0-9]*s\|[0-9]*m[0-9]*s\|[0-9.]*s\))")
+        IFS=' ' read -ra ADDR2 <<< $(cat {{ results_dir }}/openshift-cmd-out-log-${cnt}.txt | tail -5 | grep -oE "${pattern}" | head -1)
         # Calculating the passed and skipped test cases
         if [ ${{ "{" }}{{ "#" }}ADDR2[@]} -eq "5" ]
         then
-          ADDR1[3]=$((${ADDR2[0]} + ${ADDR1[3]}))
-          ADDR1[5]=$((${ADDR2[2]} + ${ADDR1[5]}))
-          ADDR2[1]=0
+          ADDR1[3]=$((${ADDR2[0]} + ${ADDR1[3]})) #Pass Count
+          ADDR1[5]=$((${ADDR2[2]} + ${ADDR1[5]})) #Skip Count
+          ADDR2[1]=0                              #Fail Count
         else
-          ADDR1[3]=$((${ADDR2[3]} + ${ADDR1[3]}))
-          ADDR1[5]=$((${ADDR2[5]} + ${ADDR1[5]}))
+          if [ ${{ "{" }}{{ "#" }}ADDR2[@]} -eq "0" ]
+            then
+              PASS_COUNT=$(cat {{ results_dir }}/openshift-cmd-out-log-${cnt}.txt | grep "^passed" | wc -l)
+              SKIP_COUNT=$(cat {{ results_dir }}/openshift-cmd-out-log-${cnt}.txt | grep "^skipped" | wc -l)
+              FAIL_COUNT=$(cat {{ results_dir }}/openshift-cmd-out-log-${cnt}.txt | grep "^failed" | wc -l)
+          fi 
+          ADDR1[3]=$((${ADDR2[3]:=${PASS_COUNT}} + ${ADDR1[3]})) #Pass Count
+          ADDR1[5]=$((${ADDR2[5]:=${SKIP_COUNT}} + ${ADDR1[5]})) #Skip Count
         fi
 
         # exiting the loop if no new test passes
@@ -211,12 +218,20 @@
       e2e_time="(${hrs}h${mins}m${secs}s)"
 
       mv {{ results_dir }}/conformance-parallel-out-${cnt}.txt {{ results_dir }}/conformance-parallel-out.txt
-      echo " ${ADDR2[1]} fail, ${ADDR1[3]} pass, ${ADDR1[5]} skip $e2e_time" >  {{ results_dir }}/summary.txt
+      echo " ${ADDR2[1]:=${FAIL_COUNT}} fail, ${ADDR1[3]} pass, ${ADDR1[5]} skip $e2e_time" >  {{ results_dir }}/summary.txt
     else
-       mv {{ results_dir }}/conformance-parallel-out-0.txt {{ results_dir }}/conformance-parallel-out.txt
-       summary=$(cat {{ results_dir }}/openshift-cmd-out-log-0.txt | tail -1 | grep -o "error: [0-9]* fail, [0-9]* pass, [0-9]* skip (\([0-9]*h[0-9]*m[0-9]*s\|[0-9]*m[0-9]*s\|[0-9.]*s\))")
-       sed -e 's/\"/\\"/g;s/.*/\"&\"/'  {{ results_dir }}/conformance-parallel-out.txt   | awk '/Failing tests:/,EOF' | tail -n +3 | head -n -4 > {{ results_dir }}/failed-e2e-results.txt
-       echo $summary |sed 's/error://' >> {{ results_dir }}/summary.txt
+      if [ ${{ "{" }}{{ "#" }}ADDR1[@]} -eq "0" ]
+        then
+          PASS_COUNT=$(cat {{ results_dir }}/openshift-cmd-out-log-0.txt | grep "^passed" | wc -l)
+          SKIP_COUNT=$(cat {{ results_dir }}/openshift-cmd-out-log-0.txt | grep "^skipped" | wc -l)
+          FAIL_COUNT=$(cat {{ results_dir }}/openshift-cmd-out-log-0.txt | grep "^failed" | wc -l)
+          echo " ${FAIL_COUNT} fail, ${PASS_COUNT} pass, ${SKIP_COUNT} skip " >  {{ results_dir }}/summary.txt
+        else      
+          summary=$(cat {{ results_dir }}/openshift-cmd-out-log-0.txt | tail -5 | grep -oE "${pattern}" | head -1)
+      fi
+      mv {{ results_dir }}/conformance-parallel-out-0.txt {{ results_dir }}/conformance-parallel-out.txt
+      sed -e 's/\"/\\"/g;s/.*/\"&\"/'  {{ results_dir }}/conformance-parallel-out.txt   | awk '/Failing tests:/,EOF' | tail -n +3 | head -n -4 > {{ results_dir }}/failed-e2e-results.txt
+      echo $summary |sed 's/error://' >> {{ results_dir }}/summary.txt
     fi
   args:
     chdir: "{{ test_dir }}/origin"


### PR DESCRIPTION
- When all the e2e test cases are passed `openshift-tests` test suite does not generating the summary as it is exiting due to monitor tests failures before generating final summary [ref](https://github.com/openshift/origin/blob/93984bd5d0965a65f82e9796cb486eaaad694713/pkg/test/ginkgo/cmd_runsuite.go#L541-L555).
- Added a workaround to get the e2e pass/fail count from `openshift-cmd-out-log-${cnt}.txt` file and generate the summary in `summary.txt`.