### PR TITLE
Updating the latest syntax for the import tasks for ovnkube-cni and ocp-migration playbooks

### DIFF
--- a/playbooks/roles/ocp-migration/tasks/main.yml
+++ b/playbooks/roles/ocp-migration/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Migrate from OpenShiftSDN to OVN-Kubernetes
-  include: sdn_to_ovnkube.yml
+  include_tasks: sdn_to_ovnkube.yml
   when: 
     - sdn_to_ovnkube == true
     - ovnkube_to_sdn == false
 
 - name: Migrate from OVN-Kubernetes to OpenShiftSDN
-  include: ovnkube_to_sdn.yml
+  include_tasks: ovnkube_to_sdn.yml
   when: 
     - sdn_to_ovnkube == false
     - ovnkube_to_sdn == true

--- a/playbooks/roles/ocp-ovnkube-cni/tasks/main.yml
+++ b/playbooks/roles/ocp-ovnkube-cni/tasks/main.yml
@@ -24,7 +24,7 @@
   - directory
 
 - name: OVNKube CNI 
-  include: "{{ cni }}"
+  include_tasks: "{{ cni }}"
   loop:
     - egress-firewall.yml
     - egress-ip.yml


### PR DESCRIPTION
- Ansible playbook failing for ovncni validation with below error.
```
+ ansible-playbook -i cni_inventory -e @ocp_ovnkube_cni_vars.yaml playbooks/ocp-ovnkube-cni.yml
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.

The error appears to be in '/home/ocp4-playbooks-extras/playbooks/roles/ocp-ovnkube-cni/tasks/main.yml': line 26, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: OVNKube CNI
  ^ here
[Pipeline] echo
Error ! OVN CNI Validation Failed!
```

Updated the code with latest syntax for ovnkube-cni and ocp-migration playbooks.
