### PR TITLE
Add check to global pull secret for compliance

### DIFF
--- a/examples/ocp_compliance_vars.yaml
+++ b/examples/ocp_compliance_vars.yaml
@@ -1,9 +1,11 @@
 ---
 # ocp-compliance vars
 compliance_enabled: false
+compliance_enable_global_secret: false
 compliance_directory: "/tmp/compliance"
 compliance_catalogsource_image: ""         # "brew.registry.redhat.io/rh-osbs/iib:327237"
 compliance_upgrade_channel: "stable"
+compliance_go_tarball: "https://go.dev/dl/go1.22.4.linux-ppc64le.tar.gz"
 compliance_e2e: false
 compliance_e2e_github_repo: ""
 compliance_e2e_github_branch: ""

--- a/playbooks/roles/ocp-compliance/README.md
+++ b/playbooks/roles/ocp-compliance/README.md
@@ -23,12 +23,14 @@ Role Variables
 | Variable                       | Required | Default     | Comments                                       |
 |--------------------------------|----------|-------------|------------------------------------------------|
 | compliance_enabled             | no       |    false    | Set it to true to run this playbook            |
+| compliance_enable_global_secret| no       |    false    | Role var to update the global pull-secret.     |
 | compliance_directory           | no       | `/tmp/compliance` | Working directory for compliance         |
 | compliance_catalogsource_image | no       |             | Catlog source index image. If not defined, default `redhat-operators` catalog source will be used |
 | compliance_upgrade_channel     | no       |    stable   | Channel version for the compliance operator    |
 | compliance_e2e                 | no       |    false    | Set it true for running e2e tests              |
 | compliance_e2e_github_repo     | no       |     ""      | github repository for running e2e tests        |
 | compliance_e2e_github_branch   | no       |    master   | github repository branch for running e2e tests |
+| compliance_go_tarball          | no       | https://go.dev/dl/go1.22.4.linux-ppc64le.tar.gz | HTTPS URL for golang tarball |
 | compliance_github_username     | no       |     ""      | Github username                                |
 | compliance_github_token        | no       |     ""      | Github token                                   |
 | compliance_cleanup             | no       |    true     | Uninstall and cleanup any existing installed version of compliance operator |

--- a/playbooks/roles/ocp-compliance/defaults/main.yml
+++ b/playbooks/roles/ocp-compliance/defaults/main.yml
@@ -1,11 +1,12 @@
 ---
 # defaults file for playbooks/roles/ocp-compliance
 compliance_enabled: false
+compliance_enable_global_secret: false
 compliance_catalogsource: "redhat-operators"
 compliance_directory: "/tmp/compliance"
 compliance_catalogsource_image: ""
 compliance_upgrade_channel: "stable"
-compliance_go_tarball: "https://go.dev/dl/go1.20.5.linux-ppc64le.tar.gz"
+compliance_go_tarball: "https://go.dev/dl/go1.22.4.linux-ppc64le.tar.gz"
 compliance_e2e: false
 compliance_e2e_github_repo: ""
 compliance_e2e_github_branch: "master"

--- a/playbooks/roles/ocp-compliance/tasks/main.yml
+++ b/playbooks/roles/ocp-compliance/tasks/main.yml
@@ -19,6 +19,7 @@
   - name: Include the global-secret-update role
     include_role:
         name: global-secret-update
+    when: compliance_enable_global_secret   
 
   - name: Set fact variable for CatalogSource name
     set_fact:


### PR DESCRIPTION
Added `compliance_enable_global_secret` parameter for not to run the global-pull secret task if the secret is already configured in cluster.
Also updated the go lang tarball version.