### PR TITLE
Fixed ocp-e2e role by replacing core make module with community.general make module

### DIFF
--- a/playbooks/roles/ocp-e2e/README.md
+++ b/playbooks/roles/ocp-e2e/README.md
@@ -25,7 +25,10 @@ Role Variables
 Dependencies
 ------------
 
- - None
+ - Install community.general collection
+ ```
+ ansible-galaxy collection install community.general
+ ```
 
 Example Playbook
 ----------------

--- a/playbooks/roles/ocp-e2e/tasks/main.yml
+++ b/playbooks/roles/ocp-e2e/tasks/main.yml
@@ -69,7 +69,7 @@
         ansible_distribution == 'Ubuntu'
 
 - name: Run make target
-  make:
+  community.general.make:
     chdir: "{{ test_dir }}/origin"
     target: WHAT=cmd/openshift-tests
   environment: "{{ e2e_env }}"


### PR DESCRIPTION
Fixed ocp-e2e role by replacing core make module with community.general make module.