### PR TITLE
Removing unnecessary until condition

### DIFF
--- a/playbooks/roles/ocp-nfd-operator/tasks/main.yml
+++ b/playbooks/roles/ocp-nfd-operator/tasks/main.yml
@@ -325,9 +325,9 @@
 - name: Verify nx-gzip label
   shell: oc get nodes -ojson | jq -r '.items[].metadata.labels' | grep nx
   register: verify_label
-  until: verify_label.stdout|int == 2
   when: check_nxgzip_label
 
 - debug:
     msg: "{{ verify_label.stdout_lines }}"
   when: check_nxgzip_label
+


### PR DESCRIPTION
Here, removing the unnecessary until condition from the playbook.
Due to condition, the script is getting failed as it is not getting the condition which is not needed