### PR TITLE
Update pods count for CO

### DIFF
--- a/playbooks/roles/ocp-compliance/tasks/main.yml
+++ b/playbooks/roles/ocp-compliance/tasks/main.yml
@@ -113,7 +113,7 @@
     - name: Check if pods are running
       shell: oc get pods -n openshift-compliance --no-headers | grep "Running" | wc -l
       register: compliance_pods
-      until: compliance_pods.stdout|int == 2
+      until: compliance_pods.stdout|int == 3
       retries: 15
       delay: 60
 


### PR DESCRIPTION
CO v1.7.0 has undergone changes in its features. It has rhcos4-stig profiles support. Hence the expected pod count after CO installation is 3.