### PR TITLE
Enhance COO playbook to support new features

### DIFF
--- a/examples/all.yaml
+++ b/examples/all.yaml
@@ -396,23 +396,27 @@ bgp_address:
 
 # ocp-coo vars
 coo_operator_deploy: true
-coo_cleanup: true
-enable_dashboard_uiplugin: false
-enable_logging_uiplugin: false
-enable_distributed_tracing_uiplugin: false
-enable_troubleshootingpanel_uiplugin: false
-coo_role_enable: false
-coo_namespace: "openshift-observability-operator"
-coo_catalogsource_name: "coo-catalog"
-coo_catalogsource_image: "brew.registry.redhat.io/rh-osbs/iib:760399"
-coo_channel: "development"
+coo_enable_global_secret: false
+coo_cleanup: false
+enable_coo_stack: true
+enable_logging_uiplugin: true
+enable_distributed_tracing_uiplugin: true
+enable_troubleshootingpanel_uiplugin: true
+enable_monitoring_uiplugin: true
+enable_perses_dashboard: true
+coo_operator_namespace: "openshift-cluster-observability-operator"
+coo_catalogsource_image: "quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/coo-fbc-v4-20@sha256:c19e912526e49dc37fdaf24b4953dd671193ca3aa6797da60721d9ddfcd4daf0"
+coo_channel: "stable"
 coo_e2e_namespace: "coo-e2e"
 coo_logstack_namespace: "openshift-logging"
-minio_image: "quay.io/minio/minio:latest"
-distributed_tracing_qe_repo: "https://github.com/openshift/distributed-tracing-qe.git"
-distributed_tracing_qe_repo_branch: "main"
+cluster_logging_channel: "stable-6.4"
+loki_channel: "stable-6.4"
+coo_catalogsource_name: "coo"
+tempo_operator_namespace: "openshift-tempo-operator"
+opentelemetry_operator_namespace: "openshift-opentelemetry-operator"
+distributed_tracing_qe_repo: "https://github.com/openshift/distributed-tracing-console-plugin.git"
+distributed_tracing_qe_repo_branch: "release-1.0"
 chainsaw_tarball: "https://github.com/kyverno/chainsaw/releases/download/v0.2.9-beta.1/chainsaw_linux_ppc64le.tar.gz"
-chainsaw_test_namespace: "chainsaw-multitenancy"
 chainsaw_path: "/usr/local/"
 coo_work_dir: "/tmp/coo_logs"
 

--- a/examples/ocp_coo_vars.yaml
+++ b/examples/ocp_coo_vars.yaml
@@ -1,24 +1,25 @@
 ---
-
-# cluster observability operator vars
-
 coo_operator_deploy: true
-coo_cleanup: true
-enable_dashboard_uiplugin: false
-enable_logging_uiplugin: false
-enable_distributed_tracing_uiplugin: false
-enable_troubleshootingpanel_uiplugin: false
-coo_role_enable: false
-coo_namespace: "openshift-observability-operator"
-coo_catalogsource_name: "coo-catalog"
-coo_catalogsource_image: "brew.registry.redhat.io/rh-osbs/iib:760399"
-coo_channel: "development"
+coo_enable_global_secret: false
+coo_cleanup: false
+enable_coo_stack: true
+enable_logging_uiplugin: true
+enable_distributed_tracing_uiplugin: true
+enable_troubleshootingpanel_uiplugin: true
+enable_monitoring_uiplugin: true
+enable_perses_dashboard: true
+coo_operator_namespace: "openshift-cluster-observability-operator"
+coo_catalogsource_image: "quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/coo-fbc-v4-20@sha256:c19e912526e49dc37fdaf24b4953dd671193ca3aa6797da60721d9ddfcd4daf0"
+coo_channel: "stable"
 coo_e2e_namespace: "coo-e2e"
 coo_logstack_namespace: "openshift-logging"
-minio_image: "quay.io/minio/minio:latest"
-distributed_tracing_qe_repo: "https://github.com/openshift/distributed-tracing-qe.git"
+cluster_logging_channel: "stable-6.4"
+loki_channel: "stable-6.4"
+coo_catalogsource_name: "coo"
+tempo_operator_namespace: "openshift-tempo-operator"
+opentelemetry_operator_namespace: "openshift-opentelemetry-operator"
+distributed_tracing_qe_repo: "https://github.com/openshift/distributed-tracing-console-plugin.git"
 distributed_tracing_qe_repo_branch: "main"
 chainsaw_tarball: "https://github.com/kyverno/chainsaw/releases/download/v0.2.9-beta.1/chainsaw_linux_ppc64le.tar.gz"
-chainsaw_test_namespace: "chainsaw-multitenancy"
 chainsaw_path: "/usr/local/"
 coo_work_dir: "/tmp/coo_logs"

--- a/playbooks/roles/ocp-coo/defaults/main.yaml
+++ b/playbooks/roles/ocp-coo/defaults/main.yaml
@@ -1,22 +1,25 @@
 ---
-
 coo_operator_deploy: true
+coo_enable_global_secret: false
 coo_cleanup: true
-enable_dashboard_uiplugin: false
+enable_coo_stack: false
 enable_logging_uiplugin: false
 enable_distributed_tracing_uiplugin: false
 enable_troubleshootingpanel_uiplugin: false
-coo_role_enable: false
-coo_namespace: "openshift-observability-operator"
-coo_catalogsource_name: "coo-catalog"
-coo_catalogsource_image: "brew.registry.redhat.io/rh-osbs/iib:760399"
-coo_channel: "development"
+enable_monitoring_uiplugin: false
+enable_perses_dashboard: false
+coo_operator_namespace: "openshift-cluster-observability-operator"
+coo_catalogsource_image: "quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/coo-fbc-v4-20@sha256:c19e912526e49dc37fdaf24b4953dd671193ca3aa6797da60721d9ddfcd4daf0"
+coo_channel: "stable"
 coo_e2e_namespace: "coo-e2e"
 coo_logstack_namespace: "openshift-logging"
-minio_image: "quay.io/minio/minio:latest"
-distributed_tracing_qe_repo: "https://github.com/openshift/distributed-tracing-qe.git"
+coo_cluster_logging_channel: "stable-6.4"
+coo_loki_channel: "stable-6.4"
+coo_catalogsource_name: "coo"
+tempo_operator_namespace: "openshift-tempo-operator"
+opentelemetry_operator_namespace: "openshift-opentelemetry-operator"
+distributed_tracing_qe_repo: "https://github.com/openshift/distributed-tracing-console-plugin.git"
 distributed_tracing_qe_repo_branch: "main"
 chainsaw_tarball: "https://github.com/kyverno/chainsaw/releases/download/v0.2.9-beta.1/chainsaw_linux_ppc64le.tar.gz"
-chainsaw_test_namespace: "chainsaw-multitenancy"
 chainsaw_path: "/usr/local/"
 coo_work_dir: "/tmp/coo_logs"

--- a/playbooks/roles/ocp-coo/files/ImageContentSourcePolicy.yml
+++ b/playbooks/roles/ocp-coo/files/ImageContentSourcePolicy.yml
@@ -1,0 +1,15 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageContentSourcePolicy
+metadata:
+  name: brew-registry
+spec:
+  repositoryDigestMirrors:
+  - mirrors:
+    - quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator
+    source: registry.redhat.io/cluster-observability-operator
+  - mirrors:
+    - brew.registry.redhat.io
+    source: registry.redhat.io
+  - mirrors:
+    - brew.registry.redhat.io
+    source: registry-proxy.engineering.redhat.com

--- a/playbooks/roles/ocp-coo/files/ImageDigestMirrorSet.yml
+++ b/playbooks/roles/ocp-coo/files/ImageDigestMirrorSet.yml
@@ -1,0 +1,9 @@
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: idms-coo
+spec:
+  imageDigestMirrors:
+  - mirrors:
+    - quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator
+    source: registry.redhat.io/cluster-observability-operator

--- a/playbooks/roles/ocp-coo/tasks/cleanup.yaml
+++ b/playbooks/roles/ocp-coo/tasks/cleanup.yaml
@@ -1,205 +1,301 @@
-- name: Clean up
+---
+- name: Clean up COO resources
   block:
-  - name: Delete prometheus-datasource configmap
-    kubernetes.core.k8s:
-      state: absent
-      namespace: openshift-config-managed
-      kind: ConfigMap
-      name: prometheus-datasource-test
+    # Clean up UI Plugins
+    - name: Get all UIPlugin resources
+      k8s_info:
+        kind: UIPlugin
+        api_version: observability.openshift.io/v1alpha1
+      register: uiplugins_result
 
-  - name: Delete test-db-plugin-admin configmap
-    kubernetes.core.k8s:
-      state: absent
-      namespace: openshift-config-managed
-      kind: ConfigMap
-      name: test-db-plugin-admin
+    - name: Delete all UIPlugins
+      kubernetes.core.k8s:
+        state: absent
+        kind: UIPlugin
+        api_version: observability.openshift.io/v1alpha1
+        name: "{{ item.metadata.name }}"
+      loop: "{{ uiplugins_result.resources | default([]) }}"
+      loop_control:
+        label: "{{ item.metadata.name }}"
 
-  - name: Register all UIPlugins name 
-    shell: oc get UIPlugin -o json | jq .items[].metadata.name
-    register: uiplugin_names
+    # Clean up monitoring stack resources
+    - name: Delete MonitoringStack and ThanosQuerier
+      kubernetes.core.k8s:
+        state: absent
+        kind: "{{ item }}"
+        namespace: "{{ coo_e2e_namespace }}"
+        name: "{{ service_name }}"
+        api_version: monitoring.rhobs/v1alpha1
+      loop:
+        - ThanosQuerier
+        - MonitoringStack
+      vars:
+        service_name: "{{ 'example-thanos' if item == 'ThanosQuerier' else 'multi-ns' }}"
+      ignore_errors: true
 
-  - name: Delete all the UIPlugins
-    shell: oc delete UIPlugin -o name {{ item }}
-    loop: "{{ uiplugin_names.stdout.split() }}"
+    # Clean up logging resources
+    - name: Delete logging stack
+      include_role:
+        name: ocp-cluster-logging
+      vars:
+        clf_clean_up: true
+      ignore_errors: true
+    
+    # Clean up distributed tracing resources
+    - name: Delete TempoStack
+      kubernetes.core.k8s:
+        state: absent
+        api_version: tempo.grafana.com/v1alpha1
+        kind: TempoStack
+        name: simplst
+        namespace: chainsaw-rbac
 
-  - name: Delete Thanoquerier
-    kubernetes.core.k8s:
-      state: absent
-      api_version: monitoring.rhobs/v1alpha1
-      namespace: "{{ coo_e2e_namespace }}"
-      kind: ThanosQuerier
-      name: example-thanos
+    - name: Delete TempoMonolithic
+      kubernetes.core.k8s:
+        state: absent
+        api_version: tempo.grafana.com/v1alpha1
+        kind: TempoMonolithic
+        name: mmo-rbac
+        namespace: chainsaw-mmo-rbac
 
-  - name: Delete MonitoringStack
-    kubernetes.core.k8s:
-      state: absent
-      api_version: monitoring.rhobs/v1alpha1
-      namespace: "{{ coo_e2e_namespace }}"
-      kind: MonitoringStack
-      name: multi-ns
+    - name: Get all namespaces
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Namespace
+      register: ns_list
 
-  - name: Check if ClusterLogging resource exists
-    k8s_info:
-      kind: ClusterLogging
-      namespace: "{{ coo_logstack_namespace }}"
-    register: cl_resource
+    - name: Filter chainsaw namespaces
+      ansible.builtin.set_fact:
+        chainsaw_namespaces: >-
+          {{
+            ns_list.resources
+            | selectattr('metadata.name', 'search', 'chainsaw')
+            | map(attribute='metadata.name')
+            | list
+          }}
 
-  - name: Delete ClusterLogging instance
-    kubernetes.core.k8s:
-      state: absent
-      api_version: "logging.openshift.io/v1"
-      namespace: "{{ coo_logstack_namespace }}"
-      kind: ClusterLogging
-      name: instance
-    when: cl_resource.resources | length > 0
+    - name: Delete chainsaw namespaces
+      kubernetes.core.k8s:
+        state: absent
+        kind: Namespace
+        name: "{{ item }}"
+      loop: "{{ chainsaw_namespaces }}"
+      loop_control:
+        label: "{{ item }}"
+      ignore_errors: true
 
-  - name: Delete ServiceAccount
-    kubernetes.core.k8s:
-      state: absent
-      api_version: v1
-      namespace: "{{ coo_logstack_namespace }}"
-      kind: ServiceAccount
-      name: logcollector
+    - name: Wait for chainsaw namespaces to be deleted
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Namespace
+        name: "{{ item }}"
+      register: chainsaw_ns_status
+      until: chainsaw_ns_status.resources | default([]) | length == 0
+      retries: 20
+      delay: 15
+      loop: "{{ chainsaw_namespaces }}"
+      loop_control:
+        label: "{{ item }}"
+      ignore_errors: true
 
-  - name: Delete collect-application-logs clusterrole
-    kubernetes.core.k8s:
-      state: absent
-      api_version: rbac.authorization.k8s.io/v1
-      name: collect-application-logs
-      kind: ClusterRole
-      
-  - name: Delete collect-infrastructure-logs clusterrole
-    kubernetes.core.k8s:
-      state: absent
-      api_version: rbac.authorization.k8s.io/v1
-      name: collect-infrastructure-logs
-      kind: ClusterRole
+    # Clean up test deployment
+    - name: Delete test data deployment
+      kubernetes.core.k8s:
+        state: absent
+        namespace: default
+        kind: Deployment
+        name: bad-deployment
+      ignore_errors: true
 
-  - name: Delete collect-audit-logs clusterrole
-    kubernetes.core.k8s:
-      state: absent
-      api_version: rbac.authorization.k8s.io/v1
-      name: collect-audit-logs
-      kind: ClusterRole
+    # Clean up working directory
+    - name: Clean up COO working directory
+      file:
+        path: "{{ coo_work_dir }}"
+        state: absent
 
-  - name: Check if ClusterLogForwarder resource exists
-    k8s_info:
-      kind: ClusterLogForwarder
-      namespace: "{{ coo_logstack_namespace }}"
-    register: clf_resource
+    # Clean up operator resources
+    - name: Define operators to cleanup
+      set_fact:
+        operators_to_cleanup:
+          - { name: cluster-observability-operator, namespace: "{{ coo_operator_namespace }}" }
+          - { name: tempo, namespace: "{{ tempo_operator_namespace }}" }
+          - { name: opentelemetry, namespace: "{{ opentelemetry_operator_namespace }}" }
 
-  - name: Delete ClusterLogForwarder instance
-    kubernetes.core.k8s:
-      state: absent
-      api_version: "observability.openshift.io/v1"
-      namespace: "{{ coo_logstack_namespace }}"
-      kind: ClusterLogForwarder
-      name: collector
-    when: clf_resource.resources | length > 0
+    - name: Get ClusterServiceVersions
+      kubernetes.core.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: ClusterServiceVersion
+        namespace: "{{ item.namespace }}"
+      register: csv_info
+      loop: "{{ operators_to_cleanup }}"
+      loop_control:
+        label: "{{ item.name }}"
 
-  - name: Delete LokiStack instance
-    kubernetes.core.k8s:
-      state: absent
-      api_version: loki.grafana.com/v1
-      namespace: "{{ coo_logstack_namespace }}"
-      kind: LokiStack
-      name: lokistack-sample
+    - name: Get CSVs to be deleted
+      set_fact:
+        csvs_to_delete: >-
+          {{
+            csv_info.results
+            | map(attribute='resources')
+            | flatten
+            | selectattr(
+                'metadata.name',
+                'search',
+                operators_to_cleanup | map(attribute='name') | join('|')
+              )
+            | list
+          }}
 
-  - name: Delete the namespace chainsaw_test_namespace
-    kubernetes.core.k8s:
-      state: absent
-      kind: Namespace
-      name: "{{ chainsaw_test_namespace }}"
+    - name: Delete ClusterServiceVersions
+      kubernetes.core.k8s:
+        state: absent
+        api_version: operators.coreos.com/v1alpha1
+        kind: ClusterServiceVersion
+        name: "{{ item.metadata.name }}"
+        namespace: "{{ item.metadata.namespace }}"
+      loop: "{{ csvs_to_delete }}"
+      loop_control:
+        label: "{{ item.metadata.name }}"
+      ignore_errors: yes
 
-  - name: Check if the chainsaw_test_namespace gets deleted
-    shell: oc get namespace --no-headers | grep "{{ chainsaw_test_namespace }}" | wc -l
-    register: chainsaw_test_namespace_count
-    until: chainsaw_test_namespace_count.stdout|int == 0
-    retries: 15
-    delay: 30
+    - name: Wait for CSV deletion
+      kubernetes.core.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: ClusterServiceVersion
+        name: "{{ item.metadata.name }}"
+        namespace: "{{ item.metadata.namespace }}"
+      register: csv_check
+      until: csv_check.resources | default([]) | length == 0
+      retries: 20
+      delay: 10
+      loop: "{{ csvs_to_delete }}"
+      loop_control:
+        label: "{{ item.metadata.name }}"
 
-  - name: Delete Test data deployment
-    kubernetes.core.k8s:
-      state: absent
-      namespace: default
-      kind: Deployment 
-      name: bad-deployment
+    - name: Define OperatorGroups to delete
+      set_fact:
+        operatorgroups_to_delete:
+          - { name: "{{ tempo_operator_namespace }}", namespace: "{{ tempo_operator_namespace }}" }
+          - { name: "{{ opentelemetry_operator_namespace }}", namespace: "{{ opentelemetry_operator_namespace }}" }
+          - { name: "{{ coo_operator_namespace }}", namespace: "{{ coo_operator_namespace }}" }
 
-  - name: Delete the namespace coo_e2e_namespace
-    kubernetes.core.k8s:
-      state: absent
-      kind: Namespace
-      name: "{{ coo_e2e_namespace }}"
+    - name: Delete OperatorGroups
+      kubernetes.core.k8s:
+        state: absent
+        api_version: operators.coreos.com/v1
+        kind: OperatorGroup
+        name: "{{ item.name }}"
+        namespace: "{{ item.namespace }}"
+      loop: "{{ operatorgroups_to_delete }}"
+      loop_control:
+        label: "{{ item.name }}"
 
-  - name: Check if the coo_e2e_namespace gets deleted
-    shell: oc get namespace --no-headers | grep "{{ coo_e2e_namespace }}" | wc -l
-    register: coo_e2e_namespace_count
-    until: coo_e2e_namespace_count.stdout|int == 0
-    retries: 15
-    delay: 30
+    - name: Wait for OperatorGroup deletion
+      kubernetes.core.k8s_info:
+        api_version: operators.coreos.com/v1
+        kind: OperatorGroup
+        name: "{{ item.name }}"
+        namespace: "{{ item.namespace }}"
+      register: og_check
+      until: og_check.resources | default([]) | length == 0
+      retries: 10
+      delay: 5
+      loop: "{{ operatorgroups_to_delete }}"
+      loop_control:
+        label: "{{ item.name }}"
 
-  - name: Delete the workspace
-    file:
-      path: "{{ coo_work_dir }}"
-      state: "absent"
+    - name: Check if Subscriptions exist
+      kubernetes.core.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: Subscription
+        namespace: "{{ item.namespace }}"
+      register: subs_info
+      loop: "{{ operators_to_cleanup }}"
+      loop_control:
+        label: "{{ item.name }}"
 
-  - name: Get the name of cluster service version
-    shell: oc get clusterserviceversion -n "{{ coo_namespace }}" | awk '{ if ($1 ~ /cluster-observability-operator/) print $1 }'
-    register: coo_csv
+    - name: Delete Subscriptions
+      kubernetes.core.k8s:
+        state: absent
+        api_version: operators.coreos.com/v1alpha1
+        kind: Subscription
+        name: "{{ item.metadata.name }}"
+        namespace: "{{ item.metadata.namespace }}"
+      ignore_errors: yes
+      loop: "{{ subs_info.results | map(attribute='resources') | flatten }}"
+      loop_control:
+        label: "{{ item.metadata.name }}"
+      when: item is defined and item.metadata.name is defined
 
-  - name: Get the name of subscription
-    shell: oc get subscription -n "{{ coo_namespace }}" | awk '{ if ($1 ~ /cluster-observability/) print $1 }'
-    register: coo_subscription
+    - name: Define namespaces to delete
+      set_fact:
+        namespaces_to_delete:
+          - "{{ tempo_operator_namespace }}"
+          - "{{ opentelemetry_operator_namespace }}"
+          - "{{ coo_operator_namespace }}"
+          - "{{ coo_e2e_namespace }}"
 
-  - name: Get the name of operator group
-    shell: oc get operatorgroup -n "{{ coo_namespace }}" | awk '{ if ($1 ~ /og/) print $1 }'
-    register: coo_operator_group
+    # Wait for operator pods to terminate
+    - name: Wait for operator namespace to be empty
+      k8s_info:
+        kind: Pod
+        namespace: "{{ item }}"
+      register: operator_pods
+      until: operator_pods.resources | default([]) | length == 0
+      retries: 15
+      delay: 20
+      ignore_errors: true
+      loop: "{{ namespaces_to_delete }}"
+      loop_control:
+        label: "{{ item }}"
 
-  - name: Delete the subscription if exists
-    kubernetes.core.k8s:
-      state: absent
-      api_version: operators.coreos.com/v1alpha1
-      kind: Subscription
-      name: "{{ coo_subscription.stdout }}"
-      namespace: "{{ coo_namespace }}"
-    when: coo_subscription.stdout|length > 0
+    - name: Delete operator namespaces
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Namespace
+        name: "{{ item }}"
+      loop: "{{ namespaces_to_delete }}"
+      loop_control:
+        label: "{{ item }}"
 
-  - name: Delete the operator group if exists
-    kubernetes.core.k8s:
-      state: absent
-      api_version: operators.coreos.com/v1
-      kind: OperatorGroup
-      name: "{{ coo_operator_group.stdout }}"
-      namespace: "{{ coo_namespace }}"
-    when: coo_operator_group.stdout|length > 0
+    - name: Wait for namespace deletion
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Namespace
+        name: "{{ item }}"
+      register: ns_status
+      until: ns_status.resources | default([]) | length == 0
+      retries: 30
+      delay: 10
+      loop: "{{ namespaces_to_delete }}"
+      loop_control:
+        label: "{{ item }}"
 
-  - name: Delete the cluster service version if exists
-    kubernetes.core.k8s:
-      state: absent
-      api_version: operators.coreos.com/v1alpha1
-      kind: ClusterServiceVersion
-      name: "{{ coo_csv.stdout }}"
-      namespace: "{{ coo_namespace }}"
-    when: coo_csv.stdout|length > 0
+    # Clean up CatalogSource and mirror resources
+    - name: Delete CatalogSource
+      kubernetes.core.k8s:
+        state: absent
+        kind: CatalogSource
+        namespace: openshift-marketplace
+        name: "{{ coo_catalogsource_name }}"
+        api_version: operators.coreos.com/v1alpha1
+      ignore_errors: true
 
-  - name: Check if all the pods has been deleted
-    shell: oc get pods -n "{{ coo_namespace }}" --no-headers | wc -l
-    register: coo_pods
-    until: coo_pods.stdout|int == 0
-    retries: 15
-    delay: 20
+    - name: Delete ImageContentSourcePolicy instance
+      kubernetes.core.k8s:
+        state: absent
+        api_version: operator.openshift.io/v1alpha1
+        kind: ImageContentSourcePolicy
+        name: brew-registry
+      ignore_errors: true
 
-  - name: Delete the namespace if exists
-    kubernetes.core.k8s:
-      state: absent
-      kind: Namespace
-      name: "{{ coo_namespace }}"
-
-  - name: Check if the namespace gets deleted
-    shell: oc get namespace --no-headers | grep openshift-observability-operator | wc -l
-    register: coo_namespace_count
-    until: coo_namespace_count.stdout|int == 0
-    retries: 15
-    delay: 30
+    - name: Delete COO ImageDigestMirrorSet
+      kubernetes.core.k8s:
+        state: absent
+        kind: ImageDigestMirrorSet
+        name: "idms-coo"
+        api_version: config.openshift.io/v1
+      ignore_errors: true
   when: coo_cleanup
   

--- a/playbooks/roles/ocp-coo/tasks/e2e.yaml
+++ b/playbooks/roles/ocp-coo/tasks/e2e.yaml
@@ -10,7 +10,7 @@
     state: directory
     mode: '0755'
 
-- name: Deploy Dashboard UIPlugin
+- name: Deploy COO stack
   block:
     - name: Create a target namespace
       kubernetes.core.k8s:
@@ -65,288 +65,36 @@
               matchLabels:
                 mso: example
 
-    - name: Verify Thanoquerier and MonitoringStack are created successfully
-      shell: oc get pods -n "{{ coo_e2e_namespace }}" --no-headers | grep -v "Running" | wc -l
-      register: mon_pods
-      until: mon_pods.stdout|int == 0 and mon_pods.stderr == ""
+    - name: Verify ThanosQuerier and MonitoringStack pods are running
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ coo_e2e_namespace }}"
+      register: mon_pods_info
+      until: mon_pods_info.resources | selectattr('status.phase','equalto','Running') | list | length >= 5
       retries: 10
       delay: 30
 
-    - name: Check prometheus metrics from thanoquerier
-      shell: oc -n "{{ coo_e2e_namespace }}" exec deploy/thanos-querier-example-thanos \
-       -- curl -k 'http://thanos-querier-example-thanos.{{ coo_e2e_namespace }}.svc:10902/api/v1/query?' --data-urlencode 'query=prometheus_build_info' | jq
-      register: prometheus_op
-
-    - name: Display prometheus metrics
-      debug:
-        msg: "{{ prometheus_op.stdout_lines }}"
-
-    - name: Create UIPlugin Controller
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: observability.openshift.io/v1alpha1
-          kind: UIPlugin
-          metadata:
-            name: dashboards 
-          spec:
-            type: Dashboards
-
-    - name: Verify Dashboards plugin
-      shell: oc -n "{{ coo_namespace }}" get pod | grep observability-ui-dashboards | grep "Running" | wc -l
-      register: dashboard_pods
-      until: dashboard_pods.stdout|int == 1 and dashboard_pods.stderr == ""
-      retries: 10
-      delay: 30
-
-    - name: Create datasource
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: v1
-          kind: ConfigMap
-          metadata:
-            name: prometheus-datasource-test
-            namespace: openshift-config-managed
-            labels:
-              console.openshift.io/dashboard-datasource: 'true'
-          data:
-            'dashboard-datasource.yaml': |-
-              kind: "Datasource"
-              metadata:
-                name: "prometheus-datasource-test"
-                project: "openshift-config-managed"
-              spec:
-                plugin:
-                  kind: "PrometheusDatasource"
-                    spec:
-                      direct_url: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
-
-    - name: Download dashboard config file
-      get_url:
-        url: "https://raw.githubusercontent.com/lihongyan1/coo_test/main/prometheus.json"
-        dest: "{{ coo_work_dir }}/prometheus.json"
-  
-    - name: Create dashbord plugin
-      shell: oc create configmap test-db-plugin-admin --from-file={{ coo_work_dir }}/prometheus.json -n openshift-config-managed
-
-    - name: Label Config map
-      shell: oc -n openshift-config-managed label cm test-db-plugin-admin console.openshift.io/dashboard=true
-  when: enable_dashboard_uiplugin
+  when: enable_coo_stack
 
 - name: Deploy logging UIPlugin
   block:
-    - name: Check if loki secret is present
-      shell: oc get secrets -n "{{ coo_logstack_namespace }}" | awk '{ if ($1 ~ /lokicred-secret/) print $1 }' | wc -l
-      register: secret_count
-      failed_when: secret_count.stdout|int == 0
+    - name: Deploy cluster logging operator and loki operator and lokistack
+      include_role:
+        name: ocp-cluster-logging
+      vars:
+        ocp_cluster_logging: true
+        cluster_log_forwarder: true
+        clf_clean_up: false
+        cluster_logging_channel: "{{ coo_cluster_logging_channel}}"
+        loki_channel: "{{ coo_loki_channel }}"
 
-    - name: Fail if secret is not present
-      fail:
-        msg: "Secret lokicred-secret not found in openshift-logging namespace"
-      when: secret_count.stdout|int == 0
-
-    - name: Get list of csv present in openshift-logging namespace
-      shell: oc get csv -n "{{ coo_logstack_namespace }}" -o jsonpath='{.items[*].metadata.name}'
-      register: csv_list
-
-    - name: Check if Loki Operator CSV exists
-      set_fact:
-        loki_installed: "{{ csv_list.stdout is contains('loki') }}"
-
-    - name: Fail if Loki Operator is not installed 
-      fail:
-        msg: "Install Loki Operator"
-      when: not loki_installed
-
-    - name: Check if Cluster Logging Operator CSV exists
-      set_fact:
-        clo_installed: "{{ csv_list.stdout is contains('cluster-logging') }}"
-
-    - name: Fail if Cluster Logging is not installed 
-      fail:
-        msg: "Install Cluster Logging Operator"
-      when: not clo_installed
-
-    - name: Get the CLO csv name
-      set_fact:
-        clo_csv_name: "{{ item }}"
-      loop: "{{ csv_list.stdout.split() }}"
-      when: item is search('cluster-logging')
-
-    - name: Get Cluster Logging csv
+    - name: Get lokistack name
       k8s_info:
-        api_version: operators.coreos.com/v1alpha1
-        kind: ClusterServiceVersion
-        namespace: "{{ coo_logstack_namespace }}"
-        name: "{{ clo_csv_name }}"
-      register: clo_csv
-
-    - name:  Set CLO version 
-      set_fact:
-        clo_version: "{{ clo_csv.resources[0].spec.version.split('.')[:2] | join('.') }}"
-
-    - name: Create Lokistack instance 
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: loki.grafana.com/v1
-          kind: LokiStack
-          metadata:
-            name: lokistack-sample
-            namespace: "{{ coo_logstack_namespace }}"
-          spec:
-            managementState: Managed
-            size: 1x.small
-            replicationFactor: 1
-            storage:
-              secret:
-                name: lokicred-secret
-                type: s3
-            storageClassName: nfs-storage-provisioner
-            tenants:
-              mode: openshift-logging
-            rules:
-              enabled: true
-              selector:
-                matchLabels:
-                  openshift.io/cluster-monitoring: 'true'
-              namespaceSelector:
-                matchLabels:
-                  openshift.io/cluster-monitoring: 'true'
-
-    - name: Create ClusterLogging instance
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: "logging.openshift.io/v1"
-          kind: "ClusterLogging"
-          metadata:
-            annotations:
-              logging.openshift.io/preview-korrel8r-console: enabled 
-            name: "instance"
-            namespace: "{{ coo_logstack_namespace }}"
-          spec:
-            managementState: "Managed"
-            logStore:
-              type: "lokistack"
-              lokistack:
-                name: lokistack-sample
-            collection:
-              type: "vector"
-              visualization:
-                ocpConsole:
-                  logsLimit: 50
-                  timeout:  6m
-                type: ocp-console
-      when: clo_version|float < 6.0
-
-    - name: Create ClusterLogForwarder instance for CLO version greater than or equal to v6.0.0
-      block:
-      - name: Create serviceAccount logcollector
-        kubernetes.core.k8s:
-          state: present
-          definition:  
-            apiVersion: v1
-            kind: ServiceAccount
-            metadata:
-              name: logcollector
-              namespace: "{{ coo_logstack_namespace }}"
-
-      - name: Create clusterrolebinding collect-application-logs
-        kubernetes.core.k8s:
-          state: present
-          definition:  
-            apiVersion: rbac.authorization.k8s.io/v1
-            kind: ClusterRoleBinding
-            metadata:
-              name: collect-application-logs
-            roleRef:
-              apiGroup: rbac.authorization.k8s.io
-              kind: ClusterRole
-              name: collect-application-logs
-            subjects:
-              - kind: ServiceAccount
-                name: logcollector
-                namespace: "{{ coo_logstack_namespace }}"
-
-      - name: Create clusterrolebinding collect-infrastructure-logs
-        kubernetes.core.k8s:
-          state: present
-          definition:  
-            apiVersion: rbac.authorization.k8s.io/v1
-            kind: ClusterRoleBinding
-            metadata:
-              name: collect-infrastructure-logs
-            roleRef:
-              apiGroup: rbac.authorization.k8s.io
-              kind: ClusterRole
-              name: collect-infrastructure-logs
-            subjects:
-              - kind: ServiceAccount
-                name: logcollector
-                namespace: "{{ coo_logstack_namespace }}"
-
-      - name: Create clusterrolebinding collect-audit-logs
-        kubernetes.core.k8s:
-          state: present
-          definition:  
-            apiVersion: rbac.authorization.k8s.io/v1
-            kind: ClusterRoleBinding
-            metadata:
-              name: collect-audit-logs
-            roleRef:
-              apiGroup: rbac.authorization.k8s.io
-              kind: ClusterRole
-              name: collect-audit-logs
-            subjects:
-              - kind: ServiceAccount
-                name: logcollector
-                namespace: "{{ coo_logstack_namespace }}"
-
-      - name: Create ClusterLogForwarder instance
-        kubernetes.core.k8s:
-          state: present
-          definition:  
-            apiVersion: observability.openshift.io/v1
-            kind: ClusterLogForwarder
-            metadata:
-              name: collector
-              namespace: "{{ coo_logstack_namespace }}"
-            spec:
-              managementState: Managed
-              outputs:
-                - lokiStack:
-                    authentication:
-                      token:
-                        from: serviceAccount
-                    target:
-                      name: lokistack-sample
-                      namespace: "{{ coo_logstack_namespace }}"
-                  name: lokistack
-                  tls:
-                    ca:
-                      configMapName: lokistack-sample-gateway-ca-bundle
-                      key: service-ca.crt
-                  type: lokiStack
-              pipelines:
-                - inputRefs:
-                    - infrastructure
-                    - audit
-                    - application
-                  name: forward-to-lokistack
-                  outputRefs:
-                    - lokistack
-              serviceAccount:
-                name: logcollector
-      when: clo_version|float >= 6.0
-
-    - name: Verify Logging stack
-      shell: oc get pods -n "{{ coo_logstack_namespace }}" --no-headers | grep logging-view | grep "Running" | wc -l
-      register: coo_pods
-      until: coo_pods.stdout|int == 1 and coo_pods.stderr == ""
-      retries: 10
-      delay: 30
+        api_version: loki.grafana.com/v1
+        kind: LokiStack
+        namespace: openshift-logging
+      register: lokistack_name
 
     - name: Enable UIPlugin
       kubernetes.core.k8s:
@@ -358,45 +106,133 @@
             name: logging
           spec:
             logging:
-              logsLimit: 20
+              logsLimit: 6
               lokiStack:
-                name: lokistack-sample
+                name: "{{ lokistack_name.resources[0].metadata.name }}"
               timeout: 6m
             type: Logging
 
     - name: Verify logging UIPlugin
-      shell: oc get pods -n "{{ coo_namespace }}" --no-headers | grep logging | grep -v "Running\|Completed" | wc -l
+      shell: oc get pods -n "{{ coo_operator_namespace }}" --no-headers | grep logging | grep "Running\|Completed" | wc -l
       register: logging_pods
-      until: logging_pods.stdout|int == 0 and logging_pods.stderr == ""
+      until: logging_pods.stdout|int == 1 and logging_pods.stderr == ""
       retries: 10
       delay: 30
-
-    - name: Verify there are no logging-view-plugin pods under "{{ coo_namespace }}"
-      shell: oc get pods -n "{{ coo_namespace }}" --no-headers | grep logging-view-plugin | wc -l
-      register: logging_view_pods
-      until: logging_view_pods.stdout|int == 0
-      retries: 10
-      delay: 10
   when: enable_logging_uiplugin
 
-- name: Deploy Distributed Tracing Console UI plugin
+- name: Check and install tempo and opentelemetry operators  
   block:
-    - name: Get Tempo Operator csv 
-      k8s_info:
+    - name: Check if Tempo Operator exists 
+      kubernetes.core.k8s_info:
         api_version: operators.coreos.com/v1alpha1
         kind: ClusterServiceVersion
         namespace: openshift-tempo-operator
       register: tempo_csv
+    
+    - name: Check if OpenTelemetry Operator exists
+      kubernetes.core.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: ClusterServiceVersion
+        namespace: openshift-opentelemetry-operator
+      register: opentelemetry_csv
 
-    - name: Check if Tempo Operator CSV exists
-      set_fact:
-        tempo_installed: "{{ tempo_csv.resources | selectattr('metadata.name', 'search', 'tempo') | list | length>0 }}"
+    - name: Install tempo operator
+      block:
+        - name: Create a target namespace for tempo operator
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: "{{ tempo_operator_namespace }}"
+                labels:
+                  openshift.io/cluster-monitoring: "true"
+        
+        - name: Create a OperatorGroup for tempo operator
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: operators.coreos.com/v1
+              kind: OperatorGroup
+              metadata:
+                name: "{{ tempo_operator_namespace }}"
+                namespace: "{{ tempo_operator_namespace }}"
 
-    - name: Fail if Tempo Operator is not installed 
-      fail:
-        msg: "Install Tempo Operator"
-      when: not tempo_installed
+        - name: Create a subscription for tempo operator
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: operators.coreos.com/v1alpha1
+              kind: Subscription
+              metadata:
+                name: "tempo-product"
+                namespace: "{{ tempo_operator_namespace }}"
+              spec:
+                channel: "{{ coo_channel }}"
+                installPlanApproval: Automatic
+                name: "tempo-product"
+                source: "redhat-operators"
+                sourceNamespace: openshift-marketplace
+        
+        - name: Verfiy tempo operator installation
+          shell: oc get pods -n "{{ tempo_operator_namespace }}" --no-headers | grep -v "Running\|Completed" | wc -l
+          register: tempo_pods
+          until: tempo_pods.stdout|int == 0 and tempo_pods.stderr == ""
+          retries: 10
+          delay: 30
+      when: tempo_csv.resources | selectattr('metadata.name', 'search', 'tempo') | list | length == 0
 
+    - name: Install opentelemetry operator
+      block:
+        - name: Create a target namespace for opentelemetry operator
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: "{{ opentelemetry_operator_namespace }}"
+                labels:
+                  openshift.io/cluster-monitoring: "true"
+        
+        - name: Create a OperatorGroup for tempo and opentelemetry operator
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: operators.coreos.com/v1
+              kind: OperatorGroup
+              metadata:
+                name: "{{ opentelemetry_operator_namespace }}"
+                namespace: "{{ opentelemetry_operator_namespace }}"
+
+        - name: Create a subscription for opentelemetry operator
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: operators.coreos.com/v1alpha1
+              kind: Subscription
+              metadata:
+                name: "opentelemetry-product"
+                namespace: "{{ opentelemetry_operator_namespace }}"
+              spec:
+                channel: "{{ coo_channel }}"
+                installPlanApproval: Automatic
+                name: "opentelemetry-product"
+                source: "redhat-operators"
+                sourceNamespace: openshift-marketplace
+
+        - name: Verfiy opentelemetry operator installation
+          shell: oc get pods -n "{{ opentelemetry_operator_namespace }}" --no-headers | grep -v "Running\|Completed" | wc -l
+          register: opentelemetry_pods
+          until: opentelemetry_pods.stdout|int == 0 and opentelemetry_pods.stderr == ""
+          retries: 10
+          delay: 30
+      when: opentelemetry_csv.resources | selectattr('metadata.name', 'search', 'opentelemetry') | list | length == 0
+  when: enable_distributed_tracing_uiplugin or enable_troubleshootingpanel_uiplugin
+
+- name: Deploy Distributed Tracing Console UI plugin
+  block:
     - name: Create the Tracing UIPlugin CR.
       kubernetes.core.k8s:
         state: present
@@ -405,21 +241,24 @@
           kind: UIPlugin
           metadata:
             name: distributed-tracing
-            namespace: "{{ coo_namespace }}"
+            namespace: "{{ coo_operator_namespace }}"
           spec:
             type: DistributedTracing
 
     - name: Verify Tracing UI plugin
-      shell: oc get pods -n {{ coo_namespace }} --no-headers | grep distributed-tracing- | grep "Running" | wc -l
-      register: tracing_pods
-      until: tracing_pods.stdout|int == 1 and tracing_pods.stderr == ""
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ coo_operator_namespace }}"
+      register: tracing_pods_info
+      until: tracing_pods_info.resources | selectattr('metadata.name', 'search', 'distributed-tracing-') | selectattr('status.phase', 'equalto', 'Running') | list | length == 1
       retries: 10
       delay: 30
 
     - name: Clone Distributed Tracing QE repo
       git:
         repo: "{{ distributed_tracing_qe_repo }}"
-        dest: "{{ coo_work_dir }}/distributed-tracing-qe"
+        dest: "{{ coo_work_dir }}/distributed-tracing-console-plugin"
         version: "{{ distributed_tracing_qe_repo_branch }}"
 
     - name: Download and untar chainsaw
@@ -427,20 +266,22 @@
         src: "{{ chainsaw_tarball }}"
         dest: "{{ chainsaw_path }}"
         remote_src: yes
-    
-    - name: Replace minio deployment image with quay_minio
-      replace:
-        path: "{{ coo_work_dir }}/distributed-tracing-qe/tests/e2e-acceptance/multitenancy/00-install-storage.yaml"
-        regexp: 'image:\s*.*'
-        replace: 'image: {{ minio_image }}'
 
     - name: Run Distributed Tracing testcases
-      shell: "{{ chainsaw_path }}/chainsaw test --apply-timeout 2m --assert-timeout 5m --skip-delete {{ coo_work_dir }}/distributed-tracing-qe/tests/e2e-acceptance/multitenancy \
-            {{ coo_work_dir }}/distributed-tracing-qe/tests/e2e-acceptance/monolithic-multitenancy-openshift/"
-            
+      shell: "{{ chainsaw_path }}/chainsaw test --skip-delete {{ coo_work_dir }}/distributed-tracing-console-plugin/tests/fixtures/chainsaw-tests"
+      register: tracing_tests
+      async: 300
+      poll: 30
+      ignore_errors: true
+
+    - name: Save the tracing tests in a file
+      copy:
+        content: "{{ tracing_tests.stdout }}"
+        dest: "{{ coo_work_dir }}/tracing_tests_output.txt"
   when: enable_distributed_tracing_uiplugin 
 
-- name: Deploy troubleshootingpanel-plugin  
+
+- name: Deploy Troubleshooting Panel UI plugin
   block:
     - name: Create a Deployment to create Test Data
       kubernetes.core.k8s:
@@ -478,16 +319,151 @@
             type: TroubleshootingPanel
  
     - name: Verify Korrel8r pod is in Running state
-      shell: oc get pods -n {{ coo_namespace }} --no-headers | grep korrel8r | grep "Running" | wc -l
-      register: korrel8r_pod
-      until: korrel8r_pod.stdout|int == 1 and korrel8r_pod_pod.stderr == ""
+      k8s_info:
+        kind: Pod
+        namespace: "{{ coo_operator_namespace }}"
+      register: korrel8r_pods
+      until: >
+        (
+          korrel8r_pods.resources
+          | selectattr('metadata.name', 'search', 'korrel8r')
+          | selectattr('status.phase', 'equalto', 'Running')
+          | list
+          | length
+        ) == 1
       retries: 10
       delay: 30
 
     - name: Verify troubleshooting-panel pod is in Running state
-      shell: oc get pods -n {{ coo_namespace }} --no-headers | grep troubleshooting-panel | grep "Running" | wc -l
-      register: troubleshooting_pod
-      until: troubleshooting_pod.stdout|int == 1 and troubleshooting_pod.stderr == ""
+      k8s_info:
+        kind: Pod
+        namespace: "{{ coo_operator_namespace }}"
+      register: troubleshooting_pods
+      until: >
+        (
+          troubleshooting_pods.resources
+          | selectattr('metadata.name', 'search', 'troubleshooting-panel')
+          | selectattr('status.phase', 'equalto', 'Running')
+          | list
+          | length
+        ) == 1
       retries: 10
       delay: 30
   when: enable_troubleshootingpanel_uiplugin
+
+- name: Deploy Incidents plugin
+  block:
+    - name: Enable Monitoring plugin
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: observability.openshift.io/v1alpha1
+          kind: UIPlugin
+          metadata:
+            name: monitoring
+          spec:
+            type: Monitoring
+            monitoring:
+              incidents:
+                enabled: true
+
+    - name: Verify Monitoring UIPlugin pod via label
+      k8s_info:
+        kind: Pod
+        namespace: "{{ coo_operator_namespace }}"
+      register: monitoring_pods_info
+      until: >
+        (
+          monitoring_pods_info.resources
+          | selectattr('metadata.name', 'search', 'health-analyzer')
+          | selectattr('status.phase', 'equalto', 'Running')
+          | list
+          | length
+        ) == 1
+      retries: 10
+      delay: 30
+
+    - name: Check metrics are exposed
+      shell: oc exec -n openshift-monitoring -it prometheus-k8s-0 -- curl -s "http://localhost:9090/api/v1/query?query=cluster:health:components"
+      register: prometheus_metrics
+
+    - name: Display prometheus metrics
+      debug:
+        msg: "{{ prometheus_metrics.stdout_lines }}"
+  when: enable_monitoring_uiplugin
+
+- name: Deploy Perses Config
+  block:
+    - name: Clone Perses Config
+      ansible.builtin.git:
+        repo: "https://github.com/perses/perses-operator.git"
+        dest: "{{ coo_work_dir }}/perses-operator"
+        force: true
+
+    - name: Change the namespace in Perses config files
+      ansible.builtin.replace:
+        path: "{{ item }}"
+        regexp: '^(\s*)namespace:.*'
+        replace: '\1namespace: "{{ coo_operator_namespace }}"'
+      loop:
+        - "{{ coo_work_dir }}/perses-operator/config/samples/openshift/openshift-cluster-sample-dashboard.yaml"
+        - "{{ coo_work_dir }}/perses-operator/config/samples/openshift/thanos-querier-datasource.yaml"
+
+    - name: Create Perses Dashboard and Datasource
+      k8s:
+        state: present
+        kubeconfig: "{{ coo_e2e_env.KUBECONFIG }}"
+        src: "{{ item }}"
+      loop:
+        - "{{ coo_work_dir }}/perses-operator/config/samples/openshift/openshift-cluster-sample-dashboard.yaml"
+        - "{{ coo_work_dir }}/perses-operator/config/samples/openshift/thanos-querier-datasource.yaml"
+      register: perses_config
+       
+    - name: Fail if any failed
+      ansible.builtin.fail:
+        msg: "Some resources failed"
+      when: |
+        perses_config.results
+        | selectattr('failed', 'defined')
+        | selectattr('failed')
+        | list
+        | length > 0    
+
+    - name: Verify Monitoring UIPlugin exists
+      k8s_info:
+        kind: UIPlugin
+        name: monitoring
+        api_version: observability.openshift.io/v1alpha1
+      register: monitoring_uiplugin
+
+    - name: Patch the Monitoring UIPlugin to enable Perses
+      kubernetes.core.k8s:
+        state: present
+        api_version: observability.openshift.io/v1alpha1
+        kind: UIPlugin
+        name: monitoring
+        merge_type: merge
+        definition:
+          spec:
+            monitoring:
+              perses:
+                enabled: true
+      when: monitoring_uiplugin.resources | selectattr('metadata.name', 'search', 'monitoring') | length > 0
+    
+    - name: Enable Perses
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: observability.openshift.io/v1alpha1
+          kind: UIPlugin
+          metadata:
+            name: monitoring
+          spec:
+            type: Monitoring
+            monitoring:
+              incidents:
+                enabled: true
+              perses:
+                enabled: true
+      when: monitoring_uiplugin.resources | selectattr('metadata.name', 'search', 'monitoring') | length == 0
+  when: enable_perses_dashboard

--- a/playbooks/roles/ocp-coo/tasks/install.yaml
+++ b/playbooks/roles/ocp-coo/tasks/install.yaml
@@ -4,55 +4,98 @@
   include_role:
     name: check-cluster-health
 
+- name: Get the ocp server version
+  shell: oc version | grep  "Server Version" | awk '{print $3}' | cut -d . -f 1,2
+  register: ocp_version
+
+- set_fact:
+    ocp_version: "{{ ocp_version.stdout }}"
+
 - name: Cluster Observability Operator deployment
   block:
-    - name: Setup a catalogsource for installing cluster observability operator
+    - name: Create ImageContentSourcePolicy and custom CatalogSource
       block:
         - name: Include the global pull-secret update role to extract podman-secret
           include_role:
             name: global-secret-update
-
-        - name: Create ImageContentSourcePolicy
-          k8s:
+          when: coo_enable_global_secret
+  
+        - name: Run ImageContentSourcePolicy
+          kubernetes.core.k8s:
             state: present
-            definition:
-              apiVersion: operator.openshift.io/v1alpha1
-              kind: ImageContentSourcePolicy
-              metadata:
-                name: brew-registry
-              spec:
-                repositoryDigestMirrors:
-                - mirrors:
-                  - brew.registry.redhat.io
-                  source: registry.redhat.io
-                - mirrors:
-                  - brew.registry.redhat.io
-                  source: registry-proxy.engineering.redhat.com
-
+            src:  "{{ role_path }}/files/ImageContentSourcePolicy.yml"
+          when: ocp_version | float == 4.12
+  
+        - name: Run ImageDigestMirrorSet
+          kubernetes.core.k8s:
+            state: present
+            src: "{{ role_path }}/files/ImageDigestMirrorSet.yml"
+          when: ocp_version | float >= 4.13
+  
+        - name: Create CatalogSource
+          template:
+            src: "{{ role_path }}/templates/CatalogSource.yaml.j2"
+            dest: "{{ role_path }}/files/CatalogSource.yml"
+  
         # Create custom CatalogSource
-        - name: Create a custom CatalogSource
-          k8s:
+        - name: Run CatalogSource
+          kubernetes.core.k8s:
             state: present
-            definition:
-              apiVersion: operators.coreos.com/v1alpha1
-              kind: CatalogSource
-              metadata:
-                name: "{{ coo_catalogsource_name }}"
-                namespace: openshift-marketplace
-              spec:
-                displayName: coo-catalog
-                icon:
-                  base64data: ""
-                  mediatype: ""
-                image: "{{ coo_catalogsource_image }}"
-                sourceType: grpc
-                grpcPodConfig:
-                  securityContextConfig: restricted
-                updateStrategy:
-                  registryPoll:
-                    interval: 1m0s
-      when: coo_catalogsource_image != '' or coo_catalogsource_image == None
-
+            src: "{{ role_path }}/files/CatalogSource.yml"
+  
+        - name: Check ImageContentSourcePolicy and CatalogSource added
+          shell:  oc get CatalogSource -n openshift-marketplace | grep "coo" |wc -l
+          register: output
+  
+        - name: Fail if CatalogSource not added
+          fail:
+            msg: "CatalogSource not added !"
+          when: output.stdout|int != 1
+  
+        - name: Set fact variable for Subscription
+          set_fact:
+            coo_op_source: "coo"
+  
+      when: coo_catalogsource_image != '' and coo_catalogsource_image != None
+  
+    # Default CatalogSource
+    - name: Use default sources
+      block: 
+        - name: Check if the ImageContentSourcePolicy exists
+          shell: oc get ImageContentSourcePolicy | grep brew-registry | wc -l
+          register: icsp
+    
+        - name: Check if the ImageDigestMirrorSet exists
+          shell: oc get ImageDigestMirrorSet | grep idms-coo | wc -l
+          register: idms
+    
+        - name: Check if the CatalogSource exists
+          shell:  oc get CatalogSource -n openshift-marketplace | grep "coo" |wc -l
+          register: output
+    
+        - name: Delete ImageContentSourcePolicy if it exists
+          shell: oc delete ImageContentSourcePolicy brew-registry
+          when: icsp.stdout|int == 1
+    
+        - name: Delete ImageDigestMirrorSet if it exists
+          shell: oc delete ImageDigestMirrorSet idms-coo
+          when: idms.stdout|int == 1
+    
+        - name: Delete CatalogSource if it exists
+          shell: oc delete CatalogSource coo -n openshift-marketplace
+          when: 
+            - output.stdout|int == 1
+    
+        - name: Set disableAllDefaultSources to false
+          shell: |
+            oc patch operatorhub.config.openshift.io/cluster -p='{"spec":{"disableAllDefaultSources":false}}' --type=merge
+    
+        - name: Set fact variable for subscription
+          set_fact:
+            coo_op_source: "redhat-operators"
+    
+      when: coo_catalogsource_image == '' or coo_catalogsource_image == None
+    
     - name: Create a target namespace
       kubernetes.core.k8s:
         state: present
@@ -60,20 +103,20 @@
           apiVersion: v1
           kind: Namespace
           metadata:
-            name: "{{ coo_namespace }}"
-    
-    - name: Create a OperatorGroup into target namespace
+            name: "{{ coo_operator_namespace }}"
+            labels:
+              openshift.io/cluster-monitoring: "true"
+        
+    - name: Create a OperatorGroup for COO
       kubernetes.core.k8s:
         state: present
         definition:
           apiVersion: operators.coreos.com/v1
           kind: OperatorGroup
           metadata:
-            name: coo-og
-            namespace: "{{ coo_namespace }}"
-            labels:
-              og_label: openshift-observability-operator
-    
+            name: "{{ coo_operator_namespace }}"
+            namespace: "{{ coo_operator_namespace }}"
+        
     - name: Create a subscription for cluster observability operator
       kubernetes.core.k8s:
         state: present
@@ -81,22 +124,22 @@
           apiVersion: operators.coreos.com/v1alpha1
           kind: Subscription
           metadata:
-            name: cluster-observability-subscription
-            namespace: "{{ coo_namespace }}"
-            labels:
-              operators.coreos.com/observability-operator.openshift-operators: ""
+            name: cluster-observability-operator
+            namespace: "{{ coo_operator_namespace }}"
           spec:
             channel: "{{ coo_channel }}"
             installPlanApproval: Automatic
             name: cluster-observability-operator
-            source: "{{ coo_catalogsource_name }}"
+            source: "{{ coo_op_source }}"
             sourceNamespace: openshift-marketplace
-
+    
     - name: Verfiy cluster observability operator installation
-      shell: oc get pods -n "{{ coo_namespace }}" --no-headers | grep -v "Running\|Completed" | wc -l
+      shell: oc get pods -n "{{ coo_operator_namespace }}" --no-headers | grep -v "Running\|Completed" | wc -l
       register: coo_pods
       until: coo_pods.stdout|int == 0 and coo_pods.stderr == ""
       retries: 10
       delay: 30
+      
   environment: "{{ coo_e2e_env }}"
   when: coo_operator_deploy
+    

--- a/playbooks/roles/ocp-coo/tasks/main.yaml
+++ b/playbooks/roles/ocp-coo/tasks/main.yaml
@@ -1,6 +1,14 @@
 ---
 
 # tasks file for playbooks/roles/ocp-coo
-- include_tasks: cleanup.yaml
-- include_tasks: install.yaml
-- include_tasks: e2e.yaml
+- name: Clean up COO operator and stack
+  include_tasks: cleanup.yaml
+  when: coo_cleanup
+
+- name: Deploy COO operator and stack
+  include_tasks: install.yaml
+  when: coo_operator_deploy and not coo_cleanup
+
+- name: Run COO E2E tests
+  include_tasks: e2e.yaml
+  when: enable_coo_stack and not coo_cleanup

--- a/playbooks/roles/ocp-coo/templates/CatalogSource.yaml.j2
+++ b/playbooks/roles/ocp-coo/templates/CatalogSource.yaml.j2
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: coo
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  publisher: redhat
+  displayName: Red Hat Operators for COO
+  image: "{{ coo_catalogsource_image }}"


### PR DESCRIPTION
Update the existing playbook to incorporate new changes/features.

- Included Monitoring plugin and perses dashboard.
- The default namespace for the logging stack is openshift-logging, and for the Cluster Observability Operator it is openshift-cluster-observability-operator. Since we are specifically testing COO functionality and logging stack is a must, I hardcoded the logging stack namespace to avoid taking user input.
- There wasn’t a specific issue with the k8s module. The shift to oc apply / oc delete is to simplify the code and reduce verbosity. Shifted back to k8s module.
- Using the ocp-cluster-logging role to setup the logging stack.