### PR TITLE
Exclude these binaries from extraction, as they are not available for Power(ocp-4.22/23/5.0).

### DIFF
--- a/playbooks/roles/ocp-e2e/tasks/main.yml
+++ b/playbooks/roles/ocp-e2e/tasks/main.yml
@@ -153,6 +153,7 @@
 # Running E2E
 - name: Prepare test suites and run e2e tests
   shell: |
+    export EXTENSION_BINARY_OVERRIDE_EXCLUDE_TAGS="cloud-credential-operator,aws-cloud-controller-manager,aws-machine-controllers,vsphere-csi-driver-operator"
     openshift-tests run openshift/conformance/parallel --dry-run | ./invert_excluded.py excluded_tests > test-suite.txt
     openshift-tests run -f ./test-suite.txt {{ repository_command }} -o {{ results_dir }}/conformance-parallel-out-0.txt --junit-dir {{ results_dir }}/conformance-parallel > {{ results_dir }}/openshift-cmd-out-log-0.txt 2>&1
     sed -e 's/\"/\\"/g;s/.*/\"&\"/'  {{ results_dir }}/conformance-parallel-out-0.txt   | awk '/Failing tests:/,EOF' | tail -n +3 | head -n -4 > {{ results_dir }}/failed-e2e-results.txt
@@ -166,6 +167,7 @@
 - name: Re run e2e failed tests
   shell: |
     cnt=0
+    export EXTENSION_BINARY_OVERRIDE_EXCLUDE_TAGS="cloud-credential-operator,aws-cloud-controller-manager,aws-machine-controllers,vsphere-csi-driver-operator"
     pattern="(error: [0-9]* fail, [0-9]* pass, [0-9]* skip|[0-9]* pass, [0-9]* skip) \(([0-9]*h[0-9]*m[0-9]*s|[0-9]*m[0-9]*s|[0-9.]*s)\)"
     IFS=' ' read -ra ADDR1 <<< $(cat {{ results_dir }}/openshift-cmd-out-log-0.txt | tail -5 | grep -oE "${pattern}" | head -1)
     if  [ "0" -ne "$(wc -l < "{{ results_dir }}/failed-e2e-results.txt")" ]


### PR DESCRIPTION
CC: @sajauddin @prb112 @sudeeshjohn 

errors during the e2e runs for ocp-4.23/5.0:
```
time="2026-06-18T17:13:31Z" level=info msg="Completed image extract for release image \"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1cecf78cd9b979a4db0aee1c5c17d9d7a102c89eed61024d2cad001e86005a20\" in 3.966545719s"
error: couldn't retrieve test suites: failed to extract test binaries: encountered errors while extracting binaries: extracted binary at path "/root/.cache/openshift-tests/quay_io_openshift-release-dev_ocp-release-nightly_sha256_9fb31629f6211a956ab503f7e479ccecf359a3bf14d4cc5be292877564dd917a_8f0e756808ab/vmware-vsphere-csi-driver-operator-tests-ext.gz" does not exist in image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1cecf78cd9b979a4db0aee1c5c17d9d7a102c89eed61024d2cad001e86005a20"
```