### PR TITLE
NFD AUTOMATION

### DIFF
--- a/examples/ocp_nfd_operator_vars.yml
+++ b/examples/ocp_nfd_operator_vars.yml
@@ -3,4 +3,4 @@ ocp_nfd: false
 update_channel: ""
 nfd_instance_image_version: ""
 nfd_catalogsource: "" # quay.io/openshift-release-dev/ocp-release-nightly:iib-int-index-art-operators-4.9
-
+check_nxgzip_label: false # set to true when the cluster deployed on p10 or p11 server

--- a/playbooks/ocp-nfd-operator.yml
+++ b/playbooks/ocp-nfd-operator.yml
@@ -1,12 +1,4 @@
 ---
-- name: Installation of the Node Feature Discovery Operator
-  hosts: bastion
-  tasks:
-  - name: Include the global-secret-update role
-    include_role:
-        name: global-secret-update
-    when: nfd_catalogsource != "" and nfd_catalogsource != None
-
 - name: Include the Node Feature Discovery Operator role
   hosts: bastion
   roles:

--- a/playbooks/roles/ocp-nfd-operator/README.md
+++ b/playbooks/roles/ocp-nfd-operator/README.md
@@ -1,29 +1,13 @@
 Node Feature Discovery (NFD) Operator Installation
 =========
-This playbook is used for Installation of NFD Operator and verification of successful installation.
+This playbook is used for Installation of NFD Operator and verificationof successful installation.
 
 
 Requirements
 ------------
 
- - Running OCP 4.x cluster is needed.
- - Role global-secret-update.
- - Create one OCP secret with name ***podman-secret***  in the default namespace which is used for global secret update and has following keys:
-   ***username***, ***password***  and ***registry***  
-
-eg. `podman-secret`
-```
-apiVersion: v1
-kind: Secret
-metadata:
-  name: podman-secret
-type: kubernetes.io/basic-auth
-stringData:
-  username: admin
-  password: t0p-Secret
-  registry: exampe.redhat.io
-```
-
+ - Running OCP 4.x or 5.x cluster is needed.
+ - Cluster must support ImageDigestMirrorSet (OCP 4.13+).
 
 Role Variables
 --------------
@@ -34,22 +18,27 @@ Role Variables
 | update_channel  | no | It uses default channel | It is used to set subscription channel for NFD Operator |
 | nfd_instance_image_version  | no | It uses cluster version(eg. 4.9) |This image is used while creating NFD Custom Resource |
 | nfd_catalogsource  | no | It uses default redhat-operators CatalogSource | It is used to set Index-Image of NFD Operator in the CatalogSource |
-| check_nxgzip_label  |no | False| set to true when using p10 server |
+| check_nxgzip_label  |no | False| set to true when using p10 or p11 server |
 
 #### Note:
 
-- To modify  *ImageContentSourcePolicy* at playbooks\roles\ocp-nfd-operator\files\ImageContentSourcePolicy.yml to change *repositoryDigestMirrors*. 
-Default sources are given below:  
-```
+- The playbook automatically detects the cluster version (4.x or 5.x) and uses the appropriate registry path.
+- To modify *ImageDigestMirrorSet*, update the template at `playbooks/roles/ocp-nfd-operator/templates/ImageDigestMirrorSet.yaml.j2`.
+- The `{{ openshift_version }}` variable is automatically set to `openshift4` or `openshift5` based on cluster version.
+
+Default ImageDigestMirrorSet configuration:
+```yaml
+spec:
+  imageDigestMirrors:
   - mirrors:
-    - brew.registry.redhat.io
-    source: registry.redhat.io
+    - quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share
+    source: registry.redhat.io/{{ openshift_version }}/ose-cluster-nfd-operator-bundle
   - mirrors:
-    - brew.registry.redhat.io
-    source: registry.stage.redhat.io
+    - quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share
+    source: registry.redhat.io/{{ openshift_version }}/ose-cluster-nfd-rhel9-operator
   - mirrors:
-    - brew.registry.redhat.io
-    source: registry-proxy.engineering.redhat.com
+    - quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share
+    source: registry.redhat.io/{{ openshift_version }}/ose-node-feature-discovery-rhel9
 ```
 
 Dependencies
@@ -61,19 +50,20 @@ Example Playbook
 ----------------
 ```
 ---
-- name: Installation of the Node Feature Discovery Operator
-  hosts: bastion
-  tasks:
-  - name: Include the global-secret-update role
-    include_role:
-        name: global-secret-update
-    when: catalogsource != "" and catalogsource != None
-
 - name: Include the Node Feature Discovery Operator role
   hosts: bastion
   roles:
   - ocp-nfd-operator
 ```
+
+What's New
+----------
+
+- **Migrated from ImageContentSourcePolicy to ImageDigestMirrorSet** (OCP 4.13+ requirement)
+- **Automatic version detection**: Playbook detects cluster version and uses appropriate registry paths
+- **Removed global-secret-update dependency**: No longer required
+- **Support for both OCP 4.x and 5.x clusters**: Uses `openshift4` or `openshift5` registry paths automatically
+
 License
 -------
 
@@ -83,5 +73,4 @@ Author Information
 ------------------
 
 varad.ahirwadkar@ibm.com
-
-
+Vaishnavi.Dukare@ibm.com

--- a/playbooks/roles/ocp-nfd-operator/tasks/main.yml
+++ b/playbooks/roles/ocp-nfd-operator/tasks/main.yml
@@ -9,21 +9,40 @@
 - name: Check all nodes are Ready
   shell: oc wait --all  --for=condition=Ready nodes 
 
-# Uses user defined ImageContentSourcePolicy and CatalogSource
-- name: Create ImageContentSourcePolicy and CatalogSource
-  block: 
+# Uses user defined ImageDigestMirrorSet and CatalogSource
+- name: Create ImageDigestMirrorSet and CatalogSource
+  block:
+  - name: Get cluster version to determine openshift version
+    shell: oc version | awk 'NR==1{print $3}' | cut -d'.' -f1
+    register: cluster_major_version
+
+  - name: Set openshift_version fact for 4.x clusters
+    set_fact:
+      openshift_version: "openshift4"
+    when: cluster_major_version.stdout == "4"
+
+  - name: Set openshift_version fact for 5.x clusters
+    set_fact:
+      openshift_version: "openshift5"
+    when: cluster_major_version.stdout == "5"
+
   - name: Create CatalogSource
     template:
       src: "{{ role_path }}/templates/CatalogSource.yaml.j2"
       dest: "{{ role_path }}/files/CatalogSource.yml"
 
-  - name: Run ImageSource
-    shell: oc apply -f "{{ role_path }}/files/ImageContentSourcePolicy.yml"
+  - name: Create ImageDigestMirrorSet
+    template:
+      src: "{{ role_path }}/templates/ImageDigestMirrorSet.yaml.j2"
+      dest: "{{ role_path }}/files/ImageDigestMirrorSet.yml" 
+
+  - name: Run ImageDigestMirrorSet
+    shell: oc apply -f "{{ role_path }}/files/ImageDigestMirrorSet.yml"
      
   - name: Run CatalogSource
     shell: oc apply -f "{{ role_path }}/files/CatalogSource.yml"
  
-  - name: Check ImageSource and CatalogSource added
+  - name: Check ImageDigestMirrorSet and CatalogSource added
     shell:  oc get CatalogSource -n openshift-marketplace | grep "nfd-catalogsource" |wc -l
     register: output
 
@@ -38,20 +57,20 @@
   when: nfd_catalogsource != '' and nfd_catalogsource != None
 
 
-# Uses default ImageContentSourcePolicy and CatalogSource
+# Uses default ImageDigestMirrorSet and CatalogSource
 - name: Use Default Sources
   block: 
-  - name: Check ImageContentSourcePolicy exists
-    shell: oc get ImageContentSourcePolicy | grep brew-registry | wc -l
-    register: icsp
+  - name: Check ImageDigestMirrorSet exists
+    shell: oc get ImageDigestMirrorSet | grep nfd-images-mirror-set | wc -l
+    register: idms
 
   - name: Check CatalogSource exists
     shell:  oc get CatalogSource -n openshift-marketplace | grep "nfd-catalogsource" |wc -l
     register: output
 
-  - name: Delete ImageContentSourcePolicy if exist
-    shell: oc delete ImageContentSourcePolicy brew-registry
-    when: icsp.stdout|int == 1
+  - name: Delete ImageDigestMirrorSet if exist
+    shell: oc delete ImageDigestMirrorSet nfd-images-mirror-set
+    when: idms.stdout|int == 1
 
   - name: Delete CatalogSource if exists
     shell: oc delete CatalogSource nfd-catalogsource -n openshift-marketplace

--- a/playbooks/roles/ocp-nfd-operator/templates/CatalogSource.yaml.j2
+++ b/playbooks/roles/ocp-nfd-operator/templates/CatalogSource.yaml.j2
@@ -6,8 +6,11 @@ metadata:
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  publisher: redhat
-  displayName: NFD Operators CatalogSource
   image: "{{ nfd_catalogsource }}"
+  displayName: Operators CatalogSource
+  publisher: Red Hat
+  updateStrategy:
+    registryPoll:
+      interval: 10m
 
 

--- a/playbooks/roles/ocp-nfd-operator/templates/ImageDigestMirrorSet.yaml.j2
+++ b/playbooks/roles/ocp-nfd-operator/templates/ImageDigestMirrorSet.yaml.j2
@@ -1,0 +1,16 @@
+---
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: nfd-images-mirror-set
+spec:
+  imageDigestMirrors:
+  - mirrors:
+    - quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share
+    source: registry.redhat.io/{{ openshift_version }}/ose-cluster-nfd-operator-bundle
+  - mirrors:
+    - quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share
+    source: registry.redhat.io/{{ openshift_version }}/ose-cluster-nfd-rhel9-operator
+  - mirrors:
+    - quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share
+    source: registry.redhat.io/{{ openshift_version }}/ose-node-feature-discovery-rhel9


### PR DESCRIPTION
This PR migrates the NFD Operator from deprecated ImageContentSourcePolicy to ImageDigestMirrorSet while adding automatic cluster version detection for OpenShift 4.x and 5.x.

It includes the IDMS migration flow, updates registry path configuration for both OCP versions, removes the global-secret-update dependency and documents the changes in README.md.
